### PR TITLE
Remove js file from html

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -173,6 +173,5 @@
         ></iframe>
       </div>
     </footer>
-    <script src="../js/index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
We do not need adding js file to html because
webpack script is adding it